### PR TITLE
Ability to intercept stuff based on the request method

### DIFF
--- a/src/main/java/com/hawolt/http/proxy/IRequest.java
+++ b/src/main/java/com/hawolt/http/proxy/IRequest.java
@@ -16,4 +16,6 @@ public interface IRequest {
     void setBody(String in);
 
     String url();
+
+    String method();
 }

--- a/src/main/java/com/hawolt/http/proxy/ProxyRequest.java
+++ b/src/main/java/com/hawolt/http/proxy/ProxyRequest.java
@@ -111,6 +111,11 @@ public class ProxyRequest implements IRequest {
     }
 
     @Override
+    public String method() {
+        return method;
+    }
+
+    @Override
     public Map<String, List<String>> getHeaders() {
         Map<String, List<String>> map = new HashMap<>();
         for (String key : headers.keySet()) {

--- a/src/main/java/com/hawolt/http/proxy/ProxyResponse.java
+++ b/src/main/java/com/hawolt/http/proxy/ProxyResponse.java
@@ -59,4 +59,9 @@ public class ProxyResponse implements IRequest {
     public String url() {
         return original.url();
     }
+
+    @Override
+    public String method() {
+        return original.method();
+    }
 }

--- a/src/main/java/com/hawolt/mitm/RewriteModule.java
+++ b/src/main/java/com/hawolt/mitm/RewriteModule.java
@@ -31,7 +31,8 @@ public abstract class RewriteModule<T extends IRequest> {
             List<RewriteRule> rules = map.get(type);
             for (RewriteRule rule : rules) {
                 if (!rule.getTarget().matcher(communication.url()).matches()) continue;
-                Logger.debug("Matching url for rule {} ", communication.url());
+                if (!rule.getMethod().equals(communication.method()) && !rule.getMethod().equals("*")) continue;
+                Logger.debug("Matching url for rule [{}] {} ", communication.method(), communication.url());
                 switch (type) {
                     case URL:
                         communication = rewriteURL(communication, rule);

--- a/src/main/java/com/hawolt/mitm/rule/RewriteRule.java
+++ b/src/main/java/com/hawolt/mitm/rule/RewriteRule.java
@@ -16,6 +16,7 @@ import java.util.regex.Pattern;
 public class RewriteRule implements IRewrite {
     private final String plain, replacement;
     private final Pattern target;
+    private final String method;
     private final RuleType type;
     private Pattern pattern;
 
@@ -24,6 +25,7 @@ public class RewriteRule implements IRewrite {
         this.type = RuleType.find(object.getString("type"));
         this.replacement = object.getString("replace");
         this.plain = object.getString("find");
+        this.method = object.getString("method");
         if (type != RuleType.REGEX) return;
         this.pattern = Pattern.compile(plain);
     }
@@ -34,6 +36,10 @@ public class RewriteRule implements IRewrite {
 
     public Pattern getTarget() {
         return target;
+    }
+
+    public String getMethod() {
+        return method;
     }
 
     public String getPlain() {


### PR DESCRIPTION
I had this problem that I wanted to intercept stuff in this request:
```
POST /summoner-ledge/v1/regions/EUN1/summoners/puuid/MY_PUUID
```

but there was another request with a completely different response which was by the same endpoint but with a `GET` method.

This allows us to have an `instructions.json` like this:

```
{
  "ingoing": {
    "body": [
      {
        "method": "GET",
        "url": "(.*)/summoner-ledge/v1/regions/(.*)/summoners/summoner-ids",
        "find": "\"unnamed\":(.*),",
        "replace": "true",
        "type": "regex"
      }
    ]
  },
  "outgoing": {
    "body": [

    ]
  }
}
```

The method field can also be set to `*`, which means all requests to that endpoint will be checked.